### PR TITLE
Increase timeout for cloud-init

### DIFF
--- a/playbooks/cloud-status.yml
+++ b/playbooks/cloud-status.yml
@@ -9,7 +9,7 @@
 
   tasks:
     - name: Wait for cloud-init to complete
-      raw: bash -c "for i in {1..30}; do if [ -f /var/lib/cloud/instance/boot-finished ]; then exit 0; fi; sleep 1; done; exit 1;"
+      raw: bash -c "for i in {1..60}; do if [ -f /var/lib/cloud/instance/boot-finished ]; then exit 0; fi; sleep 1; done; exit 1;"
       register: result
       changed_when: False
       failed_when: result.rc != 0


### PR DESCRIPTION
Back when AWS was having its...slowdown, it took longer than 30
seconds for a t2.micro to wake up. It's possible the recent AWS revamp
of t2 is getting us. Wait 60 seconds instead of 30.